### PR TITLE
Named pipe instead of stdout to ensure working serialization

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Sub-Future
 
+0.04    Sun Feb 04 13:08:20 UTC 2018
+        Named pipes instead of stdout to ensure working serialization
+
 0.03    Sat Dec 26 22:12:59 UTC 2009
         Minor documentation clarifications
         Standardize POD capitalization

--- a/lib/Sub/Future.pm
+++ b/lib/Sub/Future.pm
@@ -24,7 +24,7 @@ Sub::Future - asynchronous programming with futures (or promises)
 
 =cut
 
-our $VERSION = '0.03';
+our $VERSION = '0.04';
 
 =head1 SYNOPSIS
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 10;
+use Test::More tests => 12;
 use Sub::Future;
 
 # a scalar return value with explicit usage
@@ -35,4 +35,11 @@ use Sub::Future;
     my $later = future { sleep 3; return scalar time; };
     cmp_ok(time - $start, '<=', 1, 'future returns instantly');
     cmp_ok($later, '>', 2, 'blocks until the future is ready');
+}
+
+# make sure stdout/stderr does not interfere with return value's capturing
+{
+    my $value = future { print "Hello, World from the future!\n"; 42; };
+    is "$value", 42, "a quick scalar return without capturing stdout";
+    is "$value", 42, ".. still has the same value";
 }


### PR DESCRIPTION
Hi Michael,

Seems like your module relies on stdout to serialize/deserialize data between processes,
but should someone use stdout inside the future, the whole process breaks.

This patch fixes it and allows to address to stdout seamlessly inside the future.

Thanks for the module.